### PR TITLE
added shearing event, fixed dispenser shearing

### DIFF
--- a/src/main/java/us/timinc/mc/cobblemon/shearems/mixins/cobblemon/PokemonEntityMixin.java
+++ b/src/main/java/us/timinc/mc/cobblemon/shearems/mixins/cobblemon/PokemonEntityMixin.java
@@ -1,31 +1,26 @@
-package us.timinc.mc.cobblemon.shearems.mixins;
+package us.timinc.mc.cobblemon.shearems.mixins.cobblemon;
 
 @org.spongepowered.asm.mixin.Mixin(com.cobblemon.mod.common.entity.pokemon.PokemonEntity.class)
 public class PokemonEntityMixin extends net.minecraft.world.entity.animal.ShoulderRidingEntity {
-    net.minecraft.world.entity.player.Player shornBy = null;
-    net.minecraft.world.item.ItemStack shornWith = null;
-
     protected PokemonEntityMixin(net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.animal.ShoulderRidingEntity> entityType, net.minecraft.world.level.Level world) {
         super(entityType, world);
     }
 
     @org.spongepowered.asm.mixin.injection.Inject(method = "mobInteract", at = @org.spongepowered.asm.mixin.injection.At(value = "HEAD"))
     public void mobInteractMixinHead(net.minecraft.world.entity.player.Player player, net.minecraft.world.InteractionHand hand, org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable<net.minecraft.world.InteractionResult> cir) {
-        shornBy = player;
-        shornWith = player.getItemInHand(hand);
-    }
-
-    @org.spongepowered.asm.mixin.injection.Inject(method = "mobInteract", at = @org.spongepowered.asm.mixin.injection.At(value = "TAIL"))
-    public void mobInteractMixinTail(net.minecraft.world.entity.player.Player player, net.minecraft.world.InteractionHand hand, org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable<net.minecraft.world.InteractionResult> cir) {
-        shornBy = null;
-        shornWith = null;
+        if (player instanceof net.minecraft.server.level.ServerPlayer serverPlayer) {
+            us.timinc.mc.cobblemon.shearems.Shearems.INSTANCE.interactShearing(
+                    (com.cobblemon.mod.common.entity.pokemon.PokemonEntity) (Object) this,
+                    serverPlayer.getItemInHand(hand),
+                    serverPlayer
+            );
+        }
     }
 
     @org.spongepowered.asm.mixin.injection.Inject(method = "shear", at = @org.spongepowered.asm.mixin.injection.At(value = "INVOKE", target = "Lnet/minecraft/util/RandomSource;nextInt(I)I"), cancellable = true)
     public void sheared(net.minecraft.sounds.SoundSource shearedSoundCategory, org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
-        if (shornBy == null || shornWith == null) return;
         ci.cancel();
-        us.timinc.mc.cobblemon.shearems.Shearems.INSTANCE.dropShorn((com.cobblemon.mod.common.entity.pokemon.PokemonEntity) (Object) this, shornBy, shornWith);
+        us.timinc.mc.cobblemon.shearems.Shearems.INSTANCE.pokemonShorn((com.cobblemon.mod.common.entity.pokemon.PokemonEntity) (Object) this);
     }
 
     @Override

--- a/src/main/java/us/timinc/mc/cobblemon/shearems/mixins/minecraft/ShearsDispenseItemBehaviorMixin.java
+++ b/src/main/java/us/timinc/mc/cobblemon/shearems/mixins/minecraft/ShearsDispenseItemBehaviorMixin.java
@@ -1,0 +1,16 @@
+package us.timinc.mc.cobblemon.shearems.mixins.minecraft;
+
+@org.spongepowered.asm.mixin.Mixin(net.minecraft.core.dispenser.ShearsDispenseItemBehavior.class)
+public class ShearsDispenseItemBehaviorMixin {
+    @org.spongepowered.asm.mixin.injection.Inject(method = "execute", at = @org.spongepowered.asm.mixin.injection.At("HEAD"))
+    void tryShearLivingEntity(net.minecraft.core.dispenser.BlockSource blockSource, net.minecraft.world.item.ItemStack itemStack, org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable<net.minecraft.world.item.ItemStack> cir) {
+        net.minecraft.server.level.ServerLevel serverLevel = blockSource.level();
+        net.minecraft.core.BlockPos blockPos = blockSource.pos().relative(blockSource.state().getValue(net.minecraft.world.level.block.DispenserBlock.FACING));
+        java.util.List<net.minecraft.world.entity.LivingEntity> list = serverLevel.getEntitiesOfClass(net.minecraft.world.entity.LivingEntity.class, new net.minecraft.world.phys.AABB(blockPos), net.minecraft.world.entity.EntitySelector.NO_SPECTATORS);
+        for (net.minecraft.world.entity.LivingEntity livingEntity : list) {
+            if (livingEntity instanceof com.cobblemon.mod.common.entity.pokemon.PokemonEntity pokemonEntity) {
+                us.timinc.mc.cobblemon.shearems.Shearems.INSTANCE.dispenserShearing(pokemonEntity, itemStack);
+            }
+        }
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/shearems/droppers/ShearingDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/shearems/droppers/ShearingDropper.kt
@@ -1,8 +1,52 @@
 package us.timinc.mc.cobblemon.shearems.droppers
 
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.level.storage.loot.LootParams
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
+import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
+import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 import us.timinc.mc.cobblemon.shearems.Shearems.MOD_ID
+import us.timinc.mc.cobblemon.shearems.events.ShearemsEvents
 
 object ShearingDropper : AbstractFormDropper("shearing", MOD_ID) {
-    override fun load() {}
+    override fun load() {
+        ShearemsEvents.POKEMON_SHORN_POST.subscribe { event ->
+            val pokemonEntity = event.pokemonEntity
+            val level = pokemonEntity.level()
+            if (level !is ServerLevel) {
+                return@subscribe
+            }
+            val shornWith = event.tool
+            val shornBy = event.player
+            val pokemon = event.pokemon
+
+            val lootParams = LootParams(
+                level,
+                mapOf(
+                    LootContextParams.ORIGIN to pokemonEntity.position(),
+                    LootContextParams.THIS_ENTITY to pokemonEntity,
+                    LootConditions.PARAMS.POKEMON_DETAILS to pokemon,
+                    LootConditions.PARAMS.RELEVANT_PLAYER to shornBy,
+                    LootContextParams.TOOL to shornWith
+                ),
+                mapOf(),
+                shornBy?.luck ?: 0F
+            )
+            val context = FormDropContext(pokemonEntity.pokemon.form)
+            val drops = ShearingDropper.getDrops(
+                lootParams,
+                context
+            )
+
+            drops.forEach { drop ->
+                val itemEntity = pokemonEntity.spawnAtLocation(drop) ?: return@forEach
+                itemEntity.deltaMovement = itemEntity.deltaMovement.add(
+                    ((pokemonEntity.random.nextFloat() - pokemonEntity.random.nextFloat()) * 0.1f).toDouble(),
+                    (pokemonEntity.random.nextFloat() * 0.05f).toDouble(),
+                    ((pokemonEntity.random.nextFloat() - pokemonEntity.random.nextFloat()) * 0.1f).toDouble()
+                )
+            }
+        }
+    }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/shearems/events/PokemonShorn.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/shearems/events/PokemonShorn.kt
@@ -1,0 +1,28 @@
+package us.timinc.mc.cobblemon.shearems.events
+
+import com.cobblemon.mod.common.api.events.Cancelable
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
+import com.cobblemon.mod.common.pokemon.Pokemon
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.world.item.ItemStack
+
+interface PokemonShorn {
+    val pokemon: Pokemon
+    val pokemonEntity: PokemonEntity
+    val tool: ItemStack
+    val player: ServerPlayer?
+
+    class Pre(
+        override val pokemon: Pokemon,
+        override val pokemonEntity: PokemonEntity,
+        override val tool: ItemStack,
+        override val player: ServerPlayer?
+    ) : PokemonShorn, Cancelable()
+
+    class Post(
+        override val pokemon: Pokemon,
+        override val pokemonEntity: PokemonEntity,
+        override val tool: ItemStack,
+        override val player: ServerPlayer?
+    ) : PokemonShorn
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/shearems/events/ShearemsEvents.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/shearems/events/ShearemsEvents.kt
@@ -1,0 +1,12 @@
+package us.timinc.mc.cobblemon.shearems.events
+
+import com.cobblemon.mod.common.api.reactive.CancelableObservable
+import com.cobblemon.mod.common.api.reactive.EventObservable
+
+object ShearemsEvents {
+    @JvmField
+    val POKEMON_SHORN_PRE = CancelableObservable<PokemonShorn.Pre>()
+
+    @JvmField
+    val POKEMON_SHORN_POST = EventObservable<PokemonShorn.Post>()
+}

--- a/src/main/resources/shearems.mixins.json
+++ b/src/main/resources/shearems.mixins.json
@@ -4,7 +4,8 @@
   "package": "us.timinc.mc.cobblemon.shearems.mixins",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "PokemonEntityMixin"
+    "cobblemon.PokemonEntityMixin",
+    "minecraft.ShearsDispenseItemBehaviorMixin"
   ],
   "client": [],
   "server": [],


### PR DESCRIPTION
* added a POKEMON_SHORN_PRE and POKEMON_SHORN_POST event. PRE's cancelable, POST isn't.
* Shearing Dropper now attaches itself to the POKEMON_SHORN_POST event like most other droppers.
* moved the logic for what's shearing and with what to the main mod file as a registry, so that the info can come from multiple sources.
* added a mixin for dispenser shearing behavior, tapping into the new registry.
